### PR TITLE
destrot→destroy

### DIFF
--- a/src/main/resources/assets/destroy/lang/en_us.json
+++ b/src/main/resources/assets/destroy/lang/en_us.json
@@ -355,7 +355,7 @@
     "destroy.chemical.trichlorofluoromethane": "R-11",
     "destroy.chemical.trichlorofluoromethane.iupac": "Trichlorofluoromethane",
     "destroy.chemical.trimethylamine": "Trimethylamine",
-    "destrot.chemical.unknown": "Unknown",
+    "destroy.chemical.unknown": "Unknown",
     "destroy.chemical.vinyl_acetate": "Vinyl Acetate",
     "destroy.chemical.vinyl_acetate.iupac": "Ethenyl Ethanoate",
     "destroy.chemical.water": "Water",


### PR DESCRIPTION
"destrot.chemical.unknown"→"destroy.chemical.unknown" Seems to be a misspelling.